### PR TITLE
feat: add webview setting to adjust to full view port size

### DIFF
--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
@@ -30,10 +30,6 @@ class WebViewService : AppCompatActivity() {
         webView.settings.useWideViewPort = true
         webView.settings.loadWithOverviewMode = true
 
-        // Disable zoom controls for consistent payment flow experience
-        webView.settings.setSupportZoom(false)
-        webView.settings.builtInZoomControls = false
-
         // Register WebViewBridge to intercept window.close()
         val webViewBridge = WebViewBridge(webView, this)
 

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
@@ -26,6 +26,14 @@ class WebViewService : AppCompatActivity() {
         webView.settings.javaScriptEnabled = true
         webView.settings.domStorageEnabled = true
 
+        // Viewport settings for proper content scaling and positioning
+        webView.settings.useWideViewPort = true
+        webView.settings.loadWithOverviewMode = true
+
+        // Disable zoom controls for consistent payment flow experience
+        webView.settings.setSupportZoom(false)
+        webView.settings.builtInZoomControls = false
+
         // Register WebViewBridge to intercept window.close()
         val webViewBridge = WebViewBridge(webView, this)
 
@@ -56,12 +64,12 @@ class WebViewService : AppCompatActivity() {
 
         runOnUiThread {
             webView.webChromeClient = WebChromeClient()
-       
+
             // Set content
             setContentView(webView)
 
             // Load redirect URL with token
-             val redirectUrlWithJwtToken = "$redirectUrl&jwt=$token&redirect-url=$urlScheme"
+            val redirectUrlWithJwtToken = "$redirectUrl&jwt=$token&redirect-url=$urlScheme"
 
             // Load the URL
             webView.loadUrl(redirectUrlWithJwtToken)


### PR DESCRIPTION
 Add webview setting to adjust to full view port size

---

## Tests

- [x] Payed TR sdk integration transaction (Revolut)

---

## Screenshots / Videos

Before:
<img width="1280" height="2856" alt="Screenshot_20251201_122112" src="https://github.com/user-attachments/assets/5f10c69b-9610-4f5d-8ff4-ccda289b20bf" />

After:
<img width="1280" height="2856" alt="Screenshot_20251201_144214" src="https://github.com/user-attachments/assets/48e9d32c-4638-4a7d-abd0-d8cca151fb5e" />

---

## Notion Ticket
[NOTION TICKET](https://www.notion.so/feat-update-Android-SDK-WebView-service-2b60aa2641a7806c8fb6c4c4ea0397d0?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebView rendering: pages now auto-fit and scale more consistently across device sizes for better initial layout and readability.
  * Adjusted viewport behavior to provide a more stable and predictable display experience when loading web content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->