### PR TITLE
feat: add app-provided urlScheme for redirect banks and harden WebView close handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![License](https://img.shields.io/github/license/flizpay/flizpay-android)](LICENSE)
 [![Coverage Status](https://coveralls.io/repos/github/Flizpay/flizpay-android/badge.svg?branch=feat/add-test-coverage)](https://coveralls.io/github/Flizpay/flizpay-android?branch=feat/add-test-coverage)
 
-
 Welcome to the FLIZpay Android SDK! Easily integrate secure, seamless, and user-friendly payments directly into your Android app.
 
 ## 🚀 Overview
@@ -21,27 +20,54 @@ Get started with our 📚 [integration guide](https://www.docs.flizpay.de/docs/s
 
 ## 📦 Requirements
 
-The FLIZpay Android SDK requires Android 7 or later and is compatible with apps targeting Android 21 or above. 
+The FLIZpay Android SDK requires Android 7 or later and is compatible with apps targeting Android 21 or above.
 
 ## ⚡️ Quick Start
 
-After installing the SDK, initiate payments effortlessly:
+After installing the SDK, configure a callback scheme in your app and initiate payments:
 
 ```kotlin
-import com.github.flizpay.FlizpaySDK
+import flizpay2.flizpaysdk.FlizpaySDK
 
 FlizpaySDK.initiatePayment(
-        context,
-        token,
-        amount,
-    )
+    context = context,
+    token = token,
+    amount = amount,
+    metadata = mapOf(
+        "orderId" to "order-123",
+        "customerId" to "customer-456"
+    ),
+    urlScheme = "myapp://flizpay-return",
+    onFailure = { error ->
+        // Handle SDK or transaction setup errors
+    }
+)
+```
+
+In your app module, make sure the callback scheme matches the one passed to `urlScheme`:
+
+```kotlin
+android {
+    defaultConfig {
+        manifestPlaceholders["flizpayUrlScheme"] = "myapp"
+    }
+}
 ```
 
 ### Parameters
+
 - **`context`** (`ComponentActivity`, required): The activity of which to launch the webview from
 - **`amount`** (`String`, required): The payment amount.
 - **`token`** (`String`, required): JWT authentication token obtained from your backend.
-- **`onFailure`** (`((Throwable) -> Unit)`, optional): Callback to be executed on failure
+- **`metadata`** (`Map<String, Any?>`, optional): Additional metadata forwarded when creating the transaction.
+- **`urlScheme`** (`String`, required): The host app callback URL used when redirect-based bank authorization returns the user to your app.
+- **`onFailure`** (`((Throwable) -> Unit)`, optional): Callback to be executed on failure.
+
+### Redirect-based Bank Flows
+
+For redirect-based banks such as Revolut or ING, the SDK passes `urlScheme` to FLIZpay payer-web application so the bank app can return the user to the app that owns the WebView after authorization.
+
+The scheme configured in `manifestPlaceholders["flizpayUrlScheme"]` must match the scheme part of the `urlScheme` value you pass to `FlizpaySDK.initiatePayment(...)`.
 
 ---
 

--- a/flizpaysdk/build.gradle.kts
+++ b/flizpaysdk/build.gradle.kts
@@ -18,6 +18,7 @@ android {
         versionCode = 1
         versionName = project.version.toString()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        manifestPlaceholders["flizpayUrlScheme"] = "flizpaywebview"
     }
 
     buildTypes {

--- a/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/FlizpaySDKTest.kt
+++ b/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/FlizpaySDKTest.kt
@@ -18,6 +18,7 @@ class FlizpaySDKTest {
     private val testToken = "test-token"
     private val testAmount = "100.00"
     private val testRedirectUrl = "https://test.url"
+    private val testUrlScheme = "flizdemo://test?foo=bar"
 
     @Before
     fun setup() {
@@ -49,7 +50,7 @@ class FlizpaySDKTest {
     @Test
     fun test_successful_payment_initiation() {
         // Execute
-        FlizpaySDK.initiatePayment(mockContext, testToken, testAmount)
+        FlizpaySDK.initiatePayment(mockContext, testToken, testAmount, urlScheme = testUrlScheme)
 
         // Verify
         verify { mockContext.startActivity(any()) }
@@ -75,7 +76,7 @@ class FlizpaySDKTest {
         }
 
         // Execute
-        FlizpaySDK.initiatePayment(mockContext, testToken, testAmount) { error ->
+        FlizpaySDK.initiatePayment(mockContext, testToken, testAmount, urlScheme = testUrlScheme) { error ->
             capturedError = error
         }
 
@@ -92,11 +93,20 @@ class FlizpaySDKTest {
         every { mockContext.startActivity(capture(intentSlot)) } just Runs
 
         // Execute
-        FlizpaySDK.initiatePayment(mockContext, testToken, testAmount)
+        FlizpaySDK.initiatePayment(mockContext, testToken, testAmount, urlScheme = testUrlScheme)
 
         val capturedIntent = intentSlot.captured
 
         // Verify FLAG_ACTIVITY_NEW_TASK is set
         assertTrue(capturedIntent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun test_url_scheme_is_added_to_intent_extras() {
+        // Execute
+        FlizpaySDK.initiatePayment(mockContext, testToken, testAmount, urlScheme = testUrlScheme)
+
+        // Verify
+        verify { anyConstructed<Intent>().putExtra("urlScheme", testUrlScheme) }
     }
 }

--- a/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/FlizpaySDKTest.kt
+++ b/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/FlizpaySDKTest.kt
@@ -103,10 +103,13 @@ class FlizpaySDKTest {
 
     @Test
     fun test_url_scheme_is_added_to_intent_extras() {
+        val intentSlot = slot<Intent>()
+        every { mockContext.startActivity(capture(intentSlot)) } just Runs
+
         // Execute
         FlizpaySDK.initiatePayment(mockContext, testToken, testAmount, urlScheme = testUrlScheme)
 
         // Verify
-        verify { anyConstructed<Intent>().putExtra("urlScheme", testUrlScheme) }
+        assertTrue(intentSlot.captured.getStringExtra("urlScheme") == testUrlScheme)
     }
 }

--- a/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/WebViewBridgeTest.kt
+++ b/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/WebViewBridgeTest.kt
@@ -25,6 +25,10 @@ class WebViewBridgeTest {
 
         every { mockContext.startActivity(any()) } just runs
         every { mockContext.finish() } answers { closeFlag.set(true) }
+        every { mockWebView.post(any()) } answers {
+            firstArg<Runnable>().run()
+            true
+        }
     }
 
     @Test
@@ -54,5 +58,22 @@ class WebViewBridgeTest {
         val method = WebViewBridge::class.java.getMethod("closeWebView")
         val annotation = method.getAnnotation(android.webkit.JavascriptInterface::class.java)
         assert(annotation != null)
+    }
+
+    @Test
+    fun test_overrideWindowClose_injects_close_bridge() {
+        every { mockWebView.evaluateJavascript(any(), any()) } just Runs
+
+        webViewBridge.overrideWindowClose()
+
+        verify {
+            mockWebView.evaluateJavascript(
+                match { script ->
+                    script.contains("window.close = function()") &&
+                    script.contains("AndroidBridge.closeWebView();")
+                },
+                null
+            )
+        }
     }
 }

--- a/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/WebViewServiceTest.kt
+++ b/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/WebViewServiceTest.kt
@@ -1,6 +1,7 @@
 package flizpay2.flizpaysdk
 
 import android.content.Intent
+import android.net.Uri
 import android.webkit.WebView
 import flizpay2.flizpaysdk.lib.WebViewBridge
 import flizpay2.flizpaysdk.lib.WebViewService
@@ -49,7 +50,8 @@ class WebViewServiceTest {
 
     @Test
     fun test_URL_loading_with_token() {
-        val expectedUrl = "$testRedirectUrl&jwt=$testToken&redirect-url=$testUrlScheme"
+        val encodedUrlScheme = Uri.encode(testUrlScheme)
+        val expectedUrl = "$testRedirectUrl&jwt=$testToken&redirect-url=$encodedUrlScheme"
 
         // Simulate WebView loadUrl()
         every { mockWebView.loadUrl(any()) } just runs

--- a/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/WebViewServiceTest.kt
+++ b/flizpaysdk/src/androidTest/kotlin/flizpay2/flizpaysdk/WebViewServiceTest.kt
@@ -21,6 +21,7 @@ class WebViewServiceTest {
 
     private val testRedirectUrl = "https://test.flizpay.com/checkout"
     private val testToken = "test-token"
+    private val testUrlScheme = "flizdemo://test?foo=bar"
 
     @Before
     fun setup() {
@@ -28,6 +29,7 @@ class WebViewServiceTest {
         mockIntent = mockk(relaxed = true)
         every { mockIntent.getStringExtra("redirectUrl") } returns testRedirectUrl
         every { mockIntent.getStringExtra("token") } returns testToken
+        every { mockIntent.getStringExtra("urlScheme") } returns testUrlScheme
 
         // Mock WebView and WebViewBridge
         mockWebView = mockk(relaxed = true)
@@ -47,7 +49,7 @@ class WebViewServiceTest {
 
     @Test
     fun test_URL_loading_with_token() {
-        val expectedUrl = "$testRedirectUrl&jwt=$testToken"
+        val expectedUrl = "$testRedirectUrl&jwt=$testToken&redirect-url=$testUrlScheme"
 
         // Simulate WebView loadUrl()
         every { mockWebView.loadUrl(any()) } just runs
@@ -80,6 +82,7 @@ class WebViewServiceTest {
         // Simulate missing extras
         every { mockIntent.getStringExtra("redirectUrl") } returns null
         every { mockIntent.getStringExtra("token") } returns null
+        every { mockIntent.getStringExtra("urlScheme") } returns null
 
         // Simulate activity finishing
         every { mockActivity.finish() } just runs

--- a/flizpaysdk/src/main/AndroidManifest.xml
+++ b/flizpaysdk/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="flizpaywebview" />
+                <data android:scheme="${flizpayUrlScheme}" />
             </intent-filter>
         </activity>
     </application>

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/Constants.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/Constants.kt
@@ -1,8 +1,8 @@
 package flizpay2.flizpaysdk
 
 object Constants {
-    const val API_URL: String = "https://api.flizpay.de"
-    const val BASE_URL: String = "https://secure.flizpay.de"
+    var API_URL: String = "https://api.flizpay.de"
+    var BASE_URL: String = "https://secure.flizpay.de"
     val NO_CREDS_BANKS = listOf(
         "myaccount.ing.com",    // ING-DiBa
         "revolut.com",    // Revolut

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/Constants.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/Constants.kt
@@ -1,11 +1,9 @@
 package flizpay2.flizpaysdk
 
 object Constants {
-    const val API_URL: String = "https://api.flizpay.de"
-    const val BASE_URL: String = "https://secure.flizpay.de"
-    const val URL_SCHEME: String = "flizpaywebview://"
-    
-    val NO_CREDS_BANKS = listOf(
+    var API_URL: String = "https://api.flizpay.de"
+    var BASE_URL: String = "https://secure.flizpay.de"
+    var NO_CREDS_BANKS = listOf(
         "myaccount.ing.com",    // ING-DiBa
         "revolut.com",    // Revolut
         "consorsbank.de", // Consorsbank

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/Constants.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/Constants.kt
@@ -1,9 +1,9 @@
 package flizpay2.flizpaysdk
 
 object Constants {
-    var API_URL: String = "https://api.flizpay.de"
-    var BASE_URL: String = "https://secure.flizpay.de"
-    var NO_CREDS_BANKS = listOf(
+    const val API_URL: String = "https://api.flizpay.de"
+    const val BASE_URL: String = "https://secure.flizpay.de"
+    val NO_CREDS_BANKS = listOf(
         "myaccount.ing.com",    // ING-DiBa
         "revolut.com",    // Revolut
         "consorsbank.de", // Consorsbank

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/FlizpaySDK.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/FlizpaySDK.kt
@@ -7,7 +7,6 @@ import flizpay2.flizpaysdk.lib.TransactionService
 import flizpay2.flizpaysdk.lib.WebViewService
 
 object FlizpaySDK {
-
     /**
      * Initiates the payment flow within your SDK.
      *

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/FlizpaySDK.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/FlizpaySDK.kt
@@ -28,6 +28,7 @@ object FlizpaySDK {
      * @param amount The transaction amount.
      * @param metadata The metadata object.
      * @param config Optional configuration for URL overrides.
+     * @param urlScheme The host app callback URL used for redirect-based bank flows.
      * @param onFailure Optional callback to handle errors (e.g., show alerts).
      */
     fun initiatePayment(
@@ -36,6 +37,7 @@ object FlizpaySDK {
         amount: String,
         metadata: Map<String, Any?>? = null,
         config: FlizpayConfig? = null,
+        urlScheme: String,
         onFailure: ((Throwable) -> Unit)? = null,
     ) {
         val transactionService = TransactionService(
@@ -53,6 +55,7 @@ object FlizpaySDK {
                 val intent = Intent(context, WebViewService::class.java).apply {
                     putExtra("redirectUrl", redirectUrl)
                     putExtra("token", token)
+                    putExtra("urlScheme", urlScheme)
                 }
 
                 intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/FlizpaySDK.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/FlizpaySDK.kt
@@ -3,20 +3,8 @@ package flizpay2.flizpaysdk
 
 import android.content.Context
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import flizpay2.flizpaysdk.lib.TransactionService
 import flizpay2.flizpaysdk.lib.WebViewService
-
-/**
- * Configuration for FlizPay SDK URL overrides.
- * 
- * @param apiUrl Optional override for the API URL (defaults to production if null or empty)
- * @param baseUrl Optional override for the base URL (defaults to production if null or empty)
- */
-data class FlizpayConfig(
-    val apiUrl: String? = null,
-    val baseUrl: String? = null
-)
 
 object FlizpaySDK {
 
@@ -27,7 +15,6 @@ object FlizpaySDK {
      * @param token The JWT token fetched by the host app.
      * @param amount The transaction amount.
      * @param metadata The metadata object.
-     * @param config Optional configuration for URL overrides.
      * @param urlScheme The host app callback URL used for redirect-based bank flows.
      * @param onFailure Optional callback to handle errors (e.g., show alerts).
      */
@@ -36,21 +23,14 @@ object FlizpaySDK {
         token: String,
         amount: String,
         metadata: Map<String, Any?>? = null,
-        config: FlizpayConfig? = null,
         urlScheme: String,
         onFailure: ((Throwable) -> Unit)? = null,
     ) {
-        val transactionService = TransactionService(
-            apiUrl = config?.apiUrl,
-            baseUrl = config?.baseUrl
-        )
-        
-        // Use configured base URL or fall back to production default
-        val effectiveBaseUrl = config?.baseUrl?.takeIf { it.isNotEmpty() } ?: Constants.BASE_URL
+        val transactionService = TransactionService()
 
         transactionService.fetchTransactionInfo(token, amount, metadata) { result ->
             if(result.isSuccess) {
-                val redirectUrl = result.getOrNull() ?: effectiveBaseUrl
+                val redirectUrl = result.getOrNull() ?: Constants.BASE_URL
 
                 val intent = Intent(context, WebViewService::class.java).apply {
                     putExtra("redirectUrl", redirectUrl)

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/TransactionService.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/TransactionService.kt
@@ -7,18 +7,10 @@ import flizpay2.flizpaysdk.Constants
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody.Companion.toRequestBody
 import org.json.JSONObject
-import org.json.JSONArray
 
 
-class TransactionService(
-    apiUrl: String? = null,
-    private val baseUrl: String? = null
-) {
+class TransactionService {
     private val client = OkHttpClient()
-    
-    // Use provided URLs or fallback to production defaults
-    private val effectiveApiUrl: String = apiUrl?.takeIf { it.isNotEmpty() } ?: Constants.API_URL
-    private val effectiveBaseUrl: String = baseUrl?.takeIf { it.isNotEmpty() } ?: Constants.BASE_URL
 
     private fun Map<String, Any?>.toJsonObject(): JSONObject =
         JSONObject().apply {
@@ -34,7 +26,7 @@ class TransactionService(
         metadata: Map<String, Any?>? = null,
         completion: (Result<String>) -> Unit
     ) {
-        val url = "$effectiveApiUrl/transactions"
+        val url = "${Constants.API_URL}/transactions"
         val requestBody = JSONObject()
             .put("amount", amount)
             .put("currency", "EUR")

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
@@ -56,6 +56,13 @@ class WebViewService : AppCompatActivity() {
                 }
                 return false // Allow the WebView to load the URL
             }
+
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                // Re-apply the bridge after each navigation so payer-web can close the
+                // activity even after redirects or full page loads.
+                webViewBridge.overrideWindowClose()
+            }
         }
 
 
@@ -71,9 +78,6 @@ class WebViewService : AppCompatActivity() {
 
             // Load the URL
             webView.loadUrl(redirectUrlWithJwtToken)
-
-            // Override window.close behavior if needed
-            webViewBridge.overrideWindowClose()
         }
     }
 }

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
@@ -3,6 +3,7 @@ package flizpay2.flizpaysdk.lib
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
+import android.net.Uri
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -74,7 +75,8 @@ class WebViewService : AppCompatActivity() {
 
             // Pass the host app callback scheme to payer-web so it can register the
             // return URL for redirect-based bank authorization flows.
-            val redirectUrlWithJwtToken = "$redirectUrl&jwt=$token&redirect-url=$urlScheme"
+            val encodedUrlScheme = Uri.encode(urlScheme)
+            val redirectUrlWithJwtToken = "$redirectUrl&jwt=$token&redirect-url=$encodedUrlScheme"
 
             // Load the URL
             webView.loadUrl(redirectUrlWithJwtToken)

--- a/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
+++ b/flizpaysdk/src/main/kotlin/flizpay2/flizpaysdk/lib/WebViewService.kt
@@ -18,7 +18,9 @@ class WebViewService : AppCompatActivity() {
 
         // Get Intent Data
         val redirectUrl = intent.getStringExtra("redirectUrl") ?: return
-        val urlScheme = Constants.URL_SCHEME
+        // This callback scheme brings the user back to the host app's WebView after
+        // the bank app finishes an external authorization flow (for example Revolut).
+        val urlScheme = intent.getStringExtra("urlScheme") ?: return
         val token = intent.getStringExtra("token") ?: return
 
         // Instantiate WebView
@@ -34,7 +36,6 @@ class WebViewService : AppCompatActivity() {
         val webViewBridge = WebViewBridge(webView, this)
 
         webView.webViewClient = object : WebViewClient() {
-
             override fun shouldOverrideUrlLoading(
                 view: WebView?,
                 request: WebResourceRequest?
@@ -64,7 +65,8 @@ class WebViewService : AppCompatActivity() {
             // Set content
             setContentView(webView)
 
-            // Load redirect URL with token
+            // Pass the host app callback scheme to payer-web so it can register the
+            // return URL for redirect-based bank authorization flows.
             val redirectUrlWithJwtToken = "$redirectUrl&jwt=$token&redirect-url=$urlScheme"
 
             // Load the URL

--- a/flizpaysdk/src/test/kotlin/flizpay2/flizpaysdk/TransactionServiceTest.kt
+++ b/flizpaysdk/src/test/kotlin/flizpay2/flizpaysdk/TransactionServiceTest.kt
@@ -4,6 +4,7 @@ import flizpay2.flizpaysdk.lib.TransactionService
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.json.JSONObject
@@ -20,6 +21,7 @@ import java.util.concurrent.TimeUnit
 class TransactionServiceTest {
     private lateinit var mockWebServer: MockWebServer
     private lateinit var transactionService: TransactionService
+    private lateinit var originalApiUrl: String
     private val testToken = "test-token"
     private val testAmount = "100.00"
     @Volatile
@@ -34,13 +36,15 @@ class TransactionServiceTest {
         mockkConstructor(JSONObject::class)
         every { JSONObject().put(any<String>(), any<Any>()) } returns mockJsonObject
 
-        // Override API_URL constant for testing
+        originalApiUrl = Constants.API_URL
         Constants.API_URL = mockWebServer.url("/").toString().removeSuffix("/")
         transactionService = TransactionService()
     }
 
     @AfterEach
     fun tearDown() {
+        Constants.API_URL = originalApiUrl
+        unmockkConstructor(JSONObject::class)
         mockWebServer.shutdown()
     }
 


### PR DESCRIPTION
# Add app-provided urlScheme for redirect banks and harden WebView close handling

## What changed

- Added a required urlScheme parameter to `FlizpaySDK.initiatePayment(...)`
- Passed urlScheme through the SDK intent into WebViewService
- Appended `redirect-url=<urlScheme>` when loading payer-web so redirect-based bank flows can return to the host app
- Replaced the hardcoded SDK WebView scheme with a manifest placeholder:
   a. SDK manifest now uses `${flizpayUrlScheme}`
   b. SDK Gradle config provides `flizpayUrlScheme = "flizpaywebview"` as the default
- Removed the public `FlizpayConfig` override path from `initiatePayment(...)`
- Simplified TransactionService to always use the SDK constants instead of runtime URL overrides
- Removed the unused `Constants.URL_SCHEME`
- Fixed WebView closing after successful payment by re-injecting the window.close bridge on every page load via `onPageFinished(...)`
- Updated README with the new integration contract and callback scheme configuration

## Why
- Redirect-based banks need to return to the host app that owns the SDK WebView
- The previous fixed scheme was too rigid for integrators
- Exposing API/base URL overrides in the public SDK API polluted production usage and made the integration easier to break
- The previous window.close bridge injection happened too early and could be lost after navigation, preventing payer-web from closing the SDK WebView after successful payment

## Tests
- [x] Updated FlizpaySDKTest to cover urlScheme propagation into intent extras
- [x] Updated WebViewServiceTest to cover redirect-url query parameter handling
- [x] Added WebViewBridgeTest coverage for JS close-bridge injection
- [x] Completed TR flow transaction with N26 


## Notion
[NOTION TICKET](https://www.notion.so/feat-android-sdk-to-accept-app-url-scheme-with-initiatePayment-method-Update-docs-3200aa2641a78086b595d43f6aaa630b?v=1064dfb8616e471a856eb063ccf8fec1&source=copy_link)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Quick Start with full setup example, parameter details, guidance on matching URL schemes, and a new Redirect-based Bank Flows section.

* **New Features**
  * Payment initiation now accepts a configurable URL scheme parameter for custom redirect handling.

* **Improvements**
  * WebView flow now re-applies the window-close bridge after navigations for more reliable behavior.

* **Tests**
  * Added and updated tests covering URL scheme handling and WebView bridge injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->